### PR TITLE
sbt plugin support #232 (#235)

### DIFF
--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -36,9 +36,16 @@ jobs:
           path: ~/.m2
           key: m2
 
+      - name: Loading ivy cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.ivy2/cache
+          key: ${{ runner.os }}-ivy-${{ hashFiles('**/*.sbt') }}
+          restore-keys: |
+            ${{ runner.os }}-ivy-
 
       - name: Build library
-        run: ./gradlew build publishToMavenLocal --warning-mode all
+        run: ./gradlew build publishToMavenLocal publishAllPublicationsToIvyRepository --warning-mode all
 
       - name: Build gradle plugin
         run: ./gradlew -p plugins/gradle/graphql-java-codegen-gradle-plugin build publishToMavenLocal --warning-mode all
@@ -47,7 +54,13 @@ jobs:
         working-directory: plugins/maven/graphql-java-codegen-maven-plugin
         run: mvn install
 
+      - name: Build sbt plugin
+        working-directory: plugins/sbt/graphql-java-codegen-sbt-plugin
+        run: sbt compile publishLocal --debug
 
+      - name: Build sbt test
+        working-directory: plugins/sbt/graphql-java-codegen-sbt-plugin
+        run: sbt scripted
 
       - name: Build gradle example-server --warning-mode all
         run: ./gradlew -p plugins/gradle/example-server test --warning-mode all
@@ -62,6 +75,7 @@ jobs:
       - name: Build maven example-client
         working-directory: plugins/maven/example-client
         run: mvn package
+
 
   sonar:
     needs: build
@@ -85,6 +99,14 @@ jobs:
         with:
           path: ~/.m2
           key: m2
+
+      - name: Loading ivy cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.ivy2/cache
+          key: ${{ runner.os }}-ivy-${{ hashFiles('**/*.sbt') }}
+          restore-keys: |
+            ${{ runner.os }}-ivy-
 
       - name: Generate code coverage report
         run: ./gradlew codeCoverageReport --stacktrace

--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,14 @@ publishing {
                 password sonatypePassword
             }
         }
+        ivy {
+            url "${System.properties['user.home']}/.ivy2/local"
+            patternLayout {
+                artifact '[organisation]/[module]/[revision]/[ext]s/[artifact](-[classifier])(.[ext])'
+                // for ci and local, must publish to ivy2 local, can be used for sbt plugin
+                ivy '[organisation]/[module]/[revision]/[type]s/[artifact](.[ext])'
+            }
+        }
     }
 }
 

--- a/plugins/sbt/README.md
+++ b/plugins/sbt/README.md
@@ -1,0 +1,89 @@
+# GraphQL Codegen SBT plugin #
+
+This is a sbt plugin for https://github.com/kobylynskyi/graphql-java-codegen
+
+Server example at https://github.com/jxnu-liguobin/springboot-examples/tree/master/graphql-complete (do not use plugin, only a normal graphql server )
+
+
+![Build](https://github.com/kobylynskyi/graphql-java-codegen/workflows/Build/badge.svg)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.github.jxnu-liguobin/graphql-codegen-sbt-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.github.jxnu-liguobin/graphql-codegen-sbt-plugin)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+
+### Plugin Setup
+
+
+```scala
+// plugins.sbt
+addSbtPlugin("io.github.jxnu-liguobin" % "graphql-codegen-sbt-plugin" % "<version>")
+
+//since graphql-java-codegen V2.2.1
+```
+
+### Config
+
+
+```scala
+// build.sbt
+
+
+enablePlugins(GraphQLCodegenPlugin)
+
+
+GraphQLCodegenPluginDependencies
+
+//default graphqlJavaCodegen is release
+graphqlJavaCodegenVersion := Some("2.2.2-SNAPSHOT")
+graphqlSchemaPaths := List("src/main/resources/schema.graphqls")
+modelPackageName := Some("io.github.dreamylost.model")
+apiPackageName := Some("io.github.dreamylost.api")
+generateClient := false
+generateApis := true
+// Scala collection cannot be used. The latter one uses the put method, which is not supported by Scala collection.
+// in FB, collection is immutable
+customTypesMapping := {
+  val mapping = new util.HashMap[String, String]
+  mapping.put("Email", "io.github.dreamylost.scalar.EmailScalar")
+  //Character will conflict with java.lang.Character. maybe because Scala imports it automatically java.lang *.
+  //So we use Full class name
+  mapping
+}
+
+//Of course, you can also add a suffix to be different from it
+modelNameSuffix := Some("DO")
+
+customAnnotationsMapping := {
+  val mapping = new util.HashMap[String, String]
+  //must add this annotation
+  //property is __typename and you must with __typename while invoke, like new CharacterResponseProjection().id().name().typename()
+  //and in @JsonSubTypes.Type, name is __typename's value
+  mapping.put("Character",
+    s"""com.fasterxml.jackson.annotation.JsonTypeInfo(use=com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME, include=com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,property = "__typename")${System.lineSeparator()}@com.fasterxml.jackson.annotation.JsonSubTypes(value = {
+      |        @com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = HumanDO.class, name = "Human"),
+      |        @com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = DroidDO.class, name = "Droid")})
+      |""".stripMargin)
+  mapping
+}
+```
+
+### Codegen Options
+
+
+SBT task 
+
+1. graphqlSchemaValidate          
+    - use validate at terminal by user, can get args from terminal, such as `graphqlSchemaValidate  src/main/resources/schema.graphqls`, args split with space
+2. graphqlCodegen                 
+    - generate java code from graphql schema
+3. graphqlCodegenValidate         
+    - use validate schemas that config in build.sbt key: `graphqlSchemaPaths`
+
+
+### Plugin Options
+
+
+Please refer to [Codegen Options](../../docs/codegen-options.md)
+
+> in sbt plugin option `packageName` was rename to `generatePackageName`
+
+

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/.scalariform.conf
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/.scalariform.conf
@@ -1,0 +1,11 @@
+autoformat = true
+withBaseDirectory = true
+
+// Preferences
+alignParameters = true
+newlineAtEndOfFile = true
+rewriteArrowSymbols = false
+allowParamGroupsOnNewlines = true
+danglingCloseParenthesis = Preserve
+alignSingleLineCaseStatements = true
+doubleIndentConstructorArguments = true

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/build.sbt
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/build.sbt
@@ -1,0 +1,19 @@
+import Dependencies._
+
+name := "graphql-codegen-sbt-plugin"
+// must be equals to oss Group Id
+organization := "io.github.jxnu-liguobin"
+
+// publish only root project
+//publish / skip := true
+
+//keep version is equals with parent project `graphql-java-codegen`
+lazy val `graphql-codegen-sbt-plugin` = Project(id = "graphql-codegen-sbt-plugin", base = file(".")).
+  enablePlugins(SbtPlugin).
+  settings(Publishing.publishSettings).
+  settings(
+    sbtPlugin := true,
+    scalaVersion := Versions.scala212,
+    crossScalaVersions := List(Versions.scala212, Versions.scala211),
+    scalacOptions += "-target:jvm-1.8").
+  settings(Compiles.selfDependencies)

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/project/Dependencies.scala
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/project/Dependencies.scala
@@ -1,0 +1,27 @@
+import sbt.Keys.libraryDependencies
+import sbt._
+
+/**
+ * The dependence of the plugin itself
+ *
+ * @author 梦境迷离 dreamylost
+ * @since 2020-07-19
+ * @version v1.0
+ */
+object Dependencies {
+
+  object Versions {
+    lazy val scala212 = "2.12.12"
+    lazy val scala211 = "2.11.12"
+    val codegen = "2.4.0"
+  }
+
+  import Versions._
+
+  object Compiles {
+    val selfDependencies = libraryDependencies ++= Seq(
+      "io.github.kobylynskyi" % "graphql-java-codegen" % codegen
+    )
+  }
+
+}

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/project/Publishing.scala
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/project/Publishing.scala
@@ -1,0 +1,45 @@
+import sbt._
+import sbt.Keys._
+import xerial.sbt.Sonatype.autoImport.sonatypeProfileName
+
+/**
+ * sbt publish setting
+ *
+ * @author 梦境迷离 dreamylost
+ * @since 2020-07-19
+ * @version v1.0
+ */
+object Publishing {
+
+  //publish by sbt publishSigned
+  lazy val publishSettings = Seq(
+    credentials += Credentials(Path.userHome / ".ivy2" / ".sonatype_credentials"),
+    publishTo := {
+      val nexus = "https://oss.sonatype.org/"
+      if (isSnapshot.value)
+        Some("snapshots" at nexus + "content/repositories/snapshots")
+      else
+        Some("releases" at nexus + "service/local/staging/deploy/maven2")
+    },
+    licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT")),
+    publishMavenStyle := true,
+    publishArtifact in Test := false,
+    pomIncludeRepository := { _ => false },
+    developers := List(
+      Developer(
+        id = "dreamylost",
+        name = "梦境迷离",
+        email = "dreamylost@outlook.com",
+        url = url("https://dreamylost.cn")
+      )),
+    sonatypeProfileName := organization.value,
+    isSnapshot := version.value endsWith "SNAPSHOT",
+    homepage := Some(url("https://github.com/jxnu-liguobin")),
+    scmInfo := Some(
+      ScmInfo(
+        //it is fork from https://github.com/kobylynskyi/graphql-java-codegen
+        url("https://github.com/jxnu-liguobin/graphql-java-codegen"),
+        "scm:git@github.com:jxnu-liguobin/graphql-java-codegen.git"
+      ))
+  )
+}

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/project/build.properties
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 1.3.1

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/project/plugins.sbt
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/main/scala/io/github/dreamylost/graphql/codegen/Compat.scala
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/main/scala/io/github/dreamylost/graphql/codegen/Compat.scala
@@ -1,0 +1,27 @@
+package io.github.dreamylost.graphql.codegen
+
+import sbt.Keys.{ sourceDirectory, watchSources }
+import sbt.Watched.WatchSource
+import sbt.internal.io.Source
+import sbt.io.{ AllPassFilter, SuffixFilter }
+import sbt.{ Def, Task }
+
+/**
+ *
+ * @author 梦境迷离 dreamylost
+ * @since 2020-07-18
+ * @version v1.0
+ */
+trait Compat {
+  self: GraphQLCodegenPlugin =>
+
+  import self.GlobalImport._
+
+  val watchSourcesSetting: Def.Setting[Task[Seq[WatchSource]]] = {
+    watchSources += new Source(
+      (sourceDirectory in graphqlCodegen).value,
+      new SuffixFilter(".graphql") | new SuffixFilter(".graphqls"),
+      AllPassFilter)
+  }
+
+}

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/main/scala/io/github/dreamylost/graphql/codegen/GraphQLCodegenKeys.scala
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/main/scala/io/github/dreamylost/graphql/codegen/GraphQLCodegenKeys.scala
@@ -1,0 +1,108 @@
+package io.github.dreamylost.graphql.codegen
+
+import java.util
+
+import com.kobylynskyi.graphql.codegen.model.{ ApiNamePrefixStrategy, ApiRootInterfaceStrategy }
+import sbt._
+
+/**
+ *
+ * @author liguobin@growingio.com
+ * @version 1.0,2020/7/15
+ */
+trait GraphQLCodegenKeys {
+
+  //Conflict with SBT key
+  val generatePackageName = settingKey[Option[String]]("generatePackageName")
+
+  //Scala collection and asJava cannot be used. The latter one uses the put method, which is not supported by Scala collection
+  val customTypesMapping = settingKey[util.Map[String, String]]("customTypesMapping")
+
+  val apiNamePrefix = settingKey[Option[String]]("apiNamePrefix")
+
+  val apiNameSuffix = settingKey[String]("apiNameSuffix")
+
+  val apiRootInterfaceStrategy = settingKey[ApiRootInterfaceStrategy]("apiRootInterfaceStrategy")
+
+  val apiNamePrefixStrategy = settingKey[ApiNamePrefixStrategy]("apiNamePrefixStrategy")
+
+  val modelNamePrefix = settingKey[Option[String]]("Prefix to append to the model class names.")
+
+  val modelNameSuffix = settingKey[Option[String]]("Suffix to append to the model class names.")
+
+  val apiPackageName = settingKey[Option[String]]("Java package to use when generating the API classes.")
+
+  val modelPackageName = settingKey[Option[String]]("Java package to use when generating the model classes.")
+
+  val generateBuilder = settingKey[Boolean]("Specifies whether generated model classes should have builder.")
+
+  val generateApis = settingKey[Boolean]("Specifies whether api classes should be generated as well as model classes.")
+
+  val typeResolverPrefix = settingKey[Option[String]]("typeResolverPrefix")
+
+  val typeResolverSuffix = settingKey[String]("typeResolverSuffix")
+
+  val customAnnotationsMapping = settingKey[util.Map[String, String]]("customAnnotationsMapping")
+
+  val generateEqualsAndHashCode = settingKey[Boolean]("Specifies whether generated model classes should have equals and hashCode methods defined.")
+
+  val generateImmutableModels = settingKey[Boolean]("generateImmutableModels")
+
+  val generateToString = settingKey[Boolean]("Specifies whether generated model classes should have toString method defined.")
+
+  val subscriptionReturnType = settingKey[Option[String]]("subscriptionReturnType")
+
+  val generateAsyncApi = settingKey[Boolean]("If true, then wrap type into java.util.concurrent.CompletableFuture or subscriptionReturnType")
+
+  val modelValidationAnnotation = settingKey[String]("Annotation for mandatory (NonNull) fields. Can be None/empty.")
+
+  val generateParameterizedFieldsResolvers = settingKey[Boolean]("If true, then generate separate Resolver interface for parametrized fields. If false, then add field to the type definition and ignore field parameters.")
+
+  val generateExtensionFieldsResolvers = settingKey[Boolean]("Specifies whether all fields in extensions (extend type and extend interface) should be present in Resolver interface instead of the type class itself.")
+
+  val generateDataFetchingEnvironmentArgumentInApis = settingKey[Boolean]("If true, then graphql.schema.DataFetchingEnvironment env will be added as a last argument to all methods of root type resolvers and field resolvers.")
+
+  val generateModelsForRootTypes = settingKey[Boolean]("generateModelsForRootTypes")
+
+  val fieldsWithResolvers = settingKey[util.Set[String]]("fieldsWithResolvers")
+
+  val fieldsWithoutResolvers = settingKey[util.Set[String]]("fieldsWithoutResolvers")
+
+  val generateClient = settingKey[Boolean]("generateClient")
+
+  val requestSuffix = settingKey[String]("Specifies whether client-side classes should be generated for each query, mutation and subscription. This includes: Request class (contains input data) and ResponseProjection class (contains response fields).")
+
+  val responseSuffix = settingKey[String]("responseSuffix")
+
+  val responseProjectionSuffix = settingKey[String]("Specifies whether client-side classes should be generated for each query, mutation and subscription. This includes: Request class (contains input data) and ResponseProjection class (contains response fields).")
+
+  val parametrizedInputSuffix = settingKey[String]("parametrizedInputSuffix")
+
+  val jsonConfigurationFile = settingKey[Option[String]]("jsonConfigurationFile")
+
+  val parentInterfaces = settingKey[ParentInterfacesConfig]("parentInterfaces")
+
+  val graphqlSchemas = settingKey[SchemaFinderConfig]("graphqlSchemas")
+
+  val outputDir = settingKey[File]("outputDir")
+
+  val graphqlSchemaPaths = settingKey[Seq[String]]("Locations of GraphQL schemas.")
+
+  //use different paths
+  val graphqlSchemaValidate = inputKey[Seq[String]]("graphqlSchemaValidatePaths")
+
+  val graphqlCodegen = taskKey[Seq[File]]("Generate Java code")
+
+  val graphqlCodegenValidate = taskKey[Unit]("Validate graphql schema")
+
+  val apiAsyncReturnType = settingKey[String]("apiAsyncReturnType")
+
+  val apiAsyncReturnListType = settingKey[Option[String]]("apiAsyncReturnListType")
+
+  val directiveAnnotationsMapping = settingKey[util.HashMap[String, String]]("directiveAnnotationsMapping")
+
+  //for version
+  val javaxValidationApiVersion = settingKey[Option[String]]("javax-validation-api version")
+  val graphqlJavaCodegenVersion = settingKey[Option[String]]("graphql java codegen version")
+
+}

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/main/scala/io/github/dreamylost/graphql/codegen/GraphQLCodegenPlugin.scala
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/main/scala/io/github/dreamylost/graphql/codegen/GraphQLCodegenPlugin.scala
@@ -1,0 +1,240 @@
+package io.github.dreamylost.graphql.codegen
+
+import java.nio.file.{ Path, Paths }
+import java.util
+
+import com.kobylynskyi.graphql.codegen.{ GraphQLCodegen, GraphQLCodegenValidate }
+import com.kobylynskyi.graphql.codegen.model._
+import com.kobylynskyi.graphql.codegen.supplier.{ JsonMappingConfigSupplier, SchemaFinder }
+import sbt.{ AutoPlugin, Def, PluginTrigger, _ }
+import sbt.Keys.{ sLog, sourceManaged, _ }
+import sbt.internal.util.complete.DefaultParsers.spaceDelimited
+
+import scala.collection.JavaConverters._
+
+/**
+ *
+ * @author liguobin@growingio.com
+ * @version 1.0,2020/7/15
+ */
+object GraphQLCodegenPlugin extends GraphQLCodegenPlugin(Compile) {
+  //for auto import
+  val autoImport = GlobalImport
+}
+
+class GraphQLCodegenPlugin(configuration: Configuration) extends AutoPlugin with Compat {
+
+  //TODO if impl GraphQLCodegenConfiguration, can not use settingKey in override method
+
+  //override this by graphqlJavaCodegenVersion and javaxValidationApiVersion
+  private val jValidation = "2.0.1.Final"
+  private val codegen = "2.4.0"
+
+  object GlobalImport extends GraphQLCodegenKeys {
+
+    //should look for a way to automatically add to the classpath
+    lazy val GraphQLCodegenPluginDependencies: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
+      "javax.validation" % "validation-api" % javaxValidationApiVersion.value.getOrElse(jValidation),
+      "io.github.kobylynskyi" % "graphql-java-codegen" % graphqlJavaCodegenVersion.value.getOrElse(codegen)
+    )
+
+    lazy val schemaFinderConfig: SchemaFinderConfig = SchemaFinderConfig(null)
+    lazy val parentInterfacesConfig: ParentInterfacesConfig = ParentInterfacesConfig()
+  }
+
+  //no Auto trigger
+  //Eventually I decided not to use auto trigger
+  override def trigger: PluginTrigger = noTrigger
+
+  override def requires = sbt.plugins.JvmPlugin
+
+  import GlobalImport._
+
+  //With the implementation of some other plugins, initialization is not necessary,
+  //but maybe should be related to the dependency of key. For convenience, this is a conservative operation
+  override def globalSettings: Seq[Def.Setting[_]] = Seq(
+    graphqlSchemas := schemaFinderConfig,
+    jsonConfigurationFile := None,
+    graphqlSchemaPaths := Seq.empty,
+    graphqlSchemaValidate := Seq.empty,
+    customTypesMapping := new util.HashMap[String, String](),
+    customAnnotationsMapping := new util.HashMap[String, String](),
+    directiveAnnotationsMapping := new util.HashMap[String, String](),
+    javaxValidationApiVersion := None,
+    graphqlJavaCodegenVersion := None,
+    // suffix/prefix/strategies:
+    apiNamePrefix := None,
+    apiNameSuffix := MappingConfigConstants.DEFAULT_RESOLVER_SUFFIX,
+    apiRootInterfaceStrategy := ApiRootInterfaceStrategy.valueOf(MappingConfigConstants.DEFAULT_API_ROOT_INTERFACE_STRATEGY_STRING),
+    apiNamePrefixStrategy := ApiNamePrefixStrategy.valueOf(MappingConfigConstants.DEFAULT_API_NAME_PREFIX_STRATEGY_STRING),
+    modelNamePrefix := None,
+    modelNameSuffix := None,
+    requestSuffix := MappingConfigConstants.DEFAULT_REQUEST_SUFFIX,
+    responseSuffix := MappingConfigConstants.DEFAULT_RESPONSE_SUFFIX,
+    responseProjectionSuffix := MappingConfigConstants.DEFAULT_RESPONSE_PROJECTION_SUFFIX,
+    parametrizedInputSuffix := MappingConfigConstants.DEFAULT_PARAMETRIZED_INPUT_SUFFIX,
+    typeResolverPrefix := None,
+    typeResolverSuffix := MappingConfigConstants.DEFAULT_RESOLVER_SUFFIX,
+    subscriptionReturnType := None,
+    modelValidationAnnotation := MappingConfigConstants.DEFAULT_VALIDATION_ANNOTATION,
+    apiAsyncReturnType := MappingConfigConstants.DEFAULT_API_ASYNC_RETURN_TYPE,
+    apiAsyncReturnListType := None,
+    // package name configs:
+    apiPackageName := None,
+    modelPackageName := None,
+    // field resolvers configs:
+    fieldsWithResolvers := new util.HashSet[String](),
+    fieldsWithoutResolvers := new util.HashSet[String](),
+    // various toggles:
+    generateClient := MappingConfigConstants.DEFAULT_GENERATE_CLIENT_STRING.toBoolean,
+    generateAsyncApi := MappingConfigConstants.DEFAULT_GENERATE_ASYNC_APIS_STRING.toBoolean,
+    generateParameterizedFieldsResolvers := MappingConfigConstants.DEFAULT_GENERATE_PARAMETERIZED_FIELDS_RESOLVERS_STRING.toBoolean,
+    generateExtensionFieldsResolvers := MappingConfigConstants.DEFAULT_GENERATE_EXTENSION_FIELDS_RESOLVERS_STRING.toBoolean,
+    generateDataFetchingEnvironmentArgumentInApis := MappingConfigConstants.DEFAULT_GENERATE_DATA_FETCHING_ENV_STRING.toBoolean,
+    generateModelsForRootTypes := MappingConfigConstants.DEFAULT_GENERATE_MODELS_FOR_ROOT_TYPES_STRING.toBoolean,
+    generatePackageName := None,
+    generateBuilder := MappingConfigConstants.DEFAULT_BUILDER_STRING.toBoolean,
+    generateApis := MappingConfigConstants.DEFAULT_GENERATE_APIS_STRING.toBoolean,
+    generateEqualsAndHashCode := MappingConfigConstants.DEFAULT_EQUALS_AND_HASHCODE_STRING.toBoolean,
+    generateImmutableModels := MappingConfigConstants.DEFAULT_GENERATE_IMMUTABLE_MODELS_STRING.toBoolean,
+    generateToString := MappingConfigConstants.DEFAULT_TO_STRING_STRING.toBoolean,
+    // parent interfaces configs:
+    parentInterfaces := parentInterfacesConfig
+  )
+
+  //setting key must use in Def、:=
+  private def getMappingConfig(): Def.Initialize[MappingConfig] = Def.setting[MappingConfig] {
+
+    //TODO use builder
+    val mappingConfig = new MappingConfig
+    mappingConfig.setPackageName(generatePackageName.value.orNull)
+    mappingConfig.setCustomTypesMapping(customTypesMapping.value)
+    mappingConfig.setApiNameSuffix(apiNameSuffix.value)
+    mappingConfig.setApiNamePrefix(apiNamePrefix.value.orNull)
+    mappingConfig.setApiRootInterfaceStrategy(apiRootInterfaceStrategy.value)
+    mappingConfig.setApiNamePrefixStrategy(apiNamePrefixStrategy.value)
+    mappingConfig.setModelNamePrefix(modelNamePrefix.value.orNull)
+    mappingConfig.setModelNameSuffix(modelNameSuffix.value.orNull)
+    mappingConfig.setApiPackageName(apiPackageName.value.orNull)
+    mappingConfig.setModelPackageName(modelPackageName.value.orNull)
+    mappingConfig.setGenerateBuilder(generateBuilder.value)
+    mappingConfig.setGenerateApis(generateApis.value)
+    mappingConfig.setTypeResolverSuffix(typeResolverSuffix.value)
+    mappingConfig.setTypeResolverPrefix(typeResolverPrefix.value.orNull)
+    mappingConfig.setModelValidationAnnotation(modelValidationAnnotation.value)
+    mappingConfig.setCustomAnnotationsMapping(customAnnotationsMapping.value)
+    mappingConfig.setGenerateEqualsAndHashCode(generateEqualsAndHashCode.value)
+    mappingConfig.setGenerateImmutableModels(generateImmutableModels.value)
+    mappingConfig.setGenerateToString(generateToString.value)
+    mappingConfig.setSubscriptionReturnType(subscriptionReturnType.value.orNull)
+    mappingConfig.setGenerateAsyncApi(generateAsyncApi.value)
+    mappingConfig.setGenerateParameterizedFieldsResolvers(generateParameterizedFieldsResolvers.value)
+    mappingConfig.setGenerateDataFetchingEnvironmentArgumentInApis(generateDataFetchingEnvironmentArgumentInApis.value)
+    mappingConfig.setGenerateExtensionFieldsResolvers(generateExtensionFieldsResolvers.value)
+    mappingConfig.setGenerateModelsForRootTypes(generateModelsForRootTypes.value)
+    mappingConfig.setFieldsWithResolvers(fieldsWithResolvers.value)
+    mappingConfig.setFieldsWithoutResolvers(fieldsWithoutResolvers.value)
+    mappingConfig.setGenerateClient(generateClient.value)
+    mappingConfig.setRequestSuffix(requestSuffix.value)
+    mappingConfig.setResponseSuffix(responseSuffix.value)
+    mappingConfig.setResponseProjectionSuffix(responseProjectionSuffix.value)
+    mappingConfig.setParametrizedInputSuffix(parametrizedInputSuffix.value)
+    mappingConfig.setResolverParentInterface(parentInterfaces.value.resolver)
+    mappingConfig.setQueryResolverParentInterface(parentInterfaces.value.queryResolver)
+    mappingConfig.setMutationResolverParentInterface(parentInterfaces.value.mutationResolver)
+    mappingConfig.setSubscriptionResolverParentInterface(parentInterfaces.value.subscriptionResolver)
+    mappingConfig.setApiAsyncReturnType(apiAsyncReturnType.value)
+    mappingConfig.setApiAsyncReturnListType(apiAsyncReturnListType.value.orNull)
+    mappingConfig.setDirectiveAnnotationsMapping(directiveAnnotationsMapping.value)
+    sLog.value.debug(s"Current mapping config is <$mappingConfig>")
+    mappingConfig
+  }
+
+  //skip test
+  override lazy val projectSettings: Seq[Def.Setting[_]] = inConfig(configuration) {
+    Seq(
+      //must use sourceManaged in projectSettings
+      outputDir := {
+        val file = (sourceManaged in graphqlCodegen).value
+        if (!file.exists()) {
+          file.mkdirs()
+        }
+        sLog.value.info(s"Default outputDir is <${file.getAbsolutePath}>")
+        file
+      } //use validate that config in build.sbt
+      , graphqlCodegenValidate := {
+        val schemas = if (graphqlSchemaPaths.value.isEmpty) {
+          Seq((sourceDirectory.value / "resources/schema.graphql").getCanonicalPath).asJava
+        } else {
+          graphqlSchemaPaths.value.asJava
+        }
+        new GraphQLCodegenValidate(schemas).validate() //use validate at terminal by user
+      } // use a new src_managed for graphql, and must append to managedSourceDirectories
+      , sourceManaged in graphqlCodegen := crossTarget.value / "src_managed_graphql" //if generate code successfully but compile failed, reimport project, because ivy cache
+      , managedSourceDirectories in configuration := {
+        managedSourceDirectories.value ++ Seq((sourceManaged in graphqlCodegen).value)
+      }, javaSource := {
+        (sourceManaged in graphqlCodegen).value
+      }, managedClasspath := {
+        Classpaths.managedJars(configuration, classpathTypes.value, update.value)
+      }, graphqlSchemaValidate := {
+        //use by user
+        val args: Seq[String] = spaceDelimited("<arg>").parsed
+        new GraphQLCodegenValidate(args.asJava).validate()
+        args.foreach(a ⇒ sLog.value.info(s"Obtain args <$a>"))
+        args
+      }, graphqlCodegen := {
+        val mappingConfigSupplier: JsonMappingConfigSupplier = buildJsonSupplier(jsonConfigurationFile.value.orNull)
+        var result: Seq[File] = Seq.empty
+        try {
+          result = new GraphQLCodegen(getSchemas, outputDir.value, getMappingConfig().value, mappingConfigSupplier).generate.asScala
+          for (file ← result) {
+            sLog.value.info(s"Finish generate code, file name <${file.getName}>.")
+          }
+        } catch {
+          case e: Exception ⇒
+            sLog.value.debug(s"${e.getStackTrace}")
+            throw new Exception("Code generation failed. See above for the full exception.")
+        }
+
+        def getSchemas: util.List[String] = {
+          if (graphqlSchemaPaths != null && graphqlSchemaPaths.value.nonEmpty) return graphqlSchemaPaths.value.asJava
+          val schemasRootDir: Path = getSchemasRootDir
+          val finder: SchemaFinder = new SchemaFinder(schemasRootDir)
+          finder.setRecursive(graphqlSchemas.value.recursive)
+          finder.setIncludePattern(graphqlSchemas.value.includePattern)
+          finder.setExcludedFiles(graphqlSchemas.value.excludedFiles.asJava)
+          finder.findSchemas
+        }
+
+        def getSchemasRootDir: Path = {
+          val rootDir = graphqlSchemas.value.rootDir
+          if (rootDir == null) {
+            val default = getDefaultResourcesDirectory
+            if (default == null) throw new IllegalStateException("Default resource folder not found, please provide <rootDir> in <graphqlSchemas>")
+            else return default
+          }
+          Paths.get(rootDir)
+        }
+
+        def getDefaultResourcesDirectory: Path = {
+          val file = sourceDirectory.value / "resources"
+          if (!file.exists()) {
+            file.mkdirs()
+          }
+          val path = Paths.get(file.getPath)
+          sLog.value.info(s"Default resources path <$path>")
+          path
+        }
+
+        result
+      }
+    //watch graphql schema source
+    ) ++ watchSourcesSetting
+  }
+
+  private def buildJsonSupplier(jsonConfigurationFile: String): JsonMappingConfigSupplier = {
+    if (jsonConfigurationFile != null && jsonConfigurationFile.nonEmpty) new JsonMappingConfigSupplier(jsonConfigurationFile) else null
+  }
+
+}

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/main/scala/io/github/dreamylost/graphql/codegen/ParentInterfacesConfig.scala
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/main/scala/io/github/dreamylost/graphql/codegen/ParentInterfacesConfig.scala
@@ -1,0 +1,12 @@
+package io.github.dreamylost.graphql.codegen
+
+/**
+ *
+ * @author liguobin@growingio.com
+ * @version 1.0,2020/7/15
+ */
+case class ParentInterfacesConfig(
+    queryResolver:        String = null,
+    mutationResolver:     String = null,
+    subscriptionResolver: String = null,
+    resolver:             String = null)

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/main/scala/io/github/dreamylost/graphql/codegen/SchemaFinderConfig.scala
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/main/scala/io/github/dreamylost/graphql/codegen/SchemaFinderConfig.scala
@@ -1,0 +1,14 @@
+package io.github.dreamylost.graphql.codegen
+
+import com.kobylynskyi.graphql.codegen.supplier.SchemaFinder
+
+/**
+ *
+ * @author liguobin@growingio.com
+ * @version 1.0,2020/7/15
+ */
+case class SchemaFinderConfig(
+    rootDir:        String,
+    recursive:      Boolean     = SchemaFinder.DEFAULT_RECURSIVE,
+    includePattern: String      = SchemaFinder.DEFAULT_INCLUDE_PATTERN,
+    excludedFiles:  Set[String] = Set.empty)

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/build.sbt
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/build.sbt
@@ -1,0 +1,54 @@
+import java.util
+
+name := "example-client"
+
+organization := "io.github.jxnu-liguobin"
+
+libraryDependencies ++= Seq(
+  "org.apache.logging.log4j" %% "log4j-api-scala" % "11.0",
+  "org.apache.logging.log4j" % "log4j-api" % "2.8.2",
+  "org.apache.logging.log4j" % "log4j-core" % "2.8.2",
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.8.2",
+  "com.squareup.okhttp3" % "okhttp" % "4.7.2",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.11.1",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.1",
+  "org.json" % "json" % "20190722")
+
+
+enablePlugins(GraphQLCodegenPlugin)
+
+
+GraphQLCodegenPluginDependencies
+
+//default graphqlJavaCodegen is release
+//graphqlJavaCodegenVersion := Some("2.2.2-SNAPSHOT")
+graphqlSchemaPaths := List("src/main/resources/schema.graphqls")
+modelPackageName := Some("io.github.dreamylost.model")
+apiPackageName := Some("io.github.dreamylost.api")
+generateClient := true
+generateApis := true
+// Scala collection cannot be used. The latter one uses the put method, which is not supported by Scala collection.
+// in FB, collection is immutable
+customTypesMapping := {
+  val mapping = new util.HashMap[String, String]
+  mapping.put("Email", "io.github.dreamylost.scalar.EmailScalar")
+  //Character will conflict with java.lang.Character. maybe because Scala imports it automatically java.lang *.
+  //So we use Full class name
+  mapping
+}
+
+//Of course, you can also add a suffix to be different from it
+modelNameSuffix := Some("DO")
+
+customAnnotationsMapping := {
+  val mapping = new util.HashMap[String, String]
+  //must add this annotation
+  //property is __typename and you must with __typename while invoke, like new CharacterResponseProjection().id().name().typename()
+  //and in @JsonSubTypes.Type, name is __typename's value
+  mapping.put("Character",
+    s"""com.fasterxml.jackson.annotation.JsonTypeInfo(use=com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME, include=com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,property = "__typename")${System.lineSeparator()}@com.fasterxml.jackson.annotation.JsonSubTypes(value = {
+      |        @com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = HumanDO.class, name = "Human"),
+      |        @com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = DroidDO.class, name = "Droid")})
+      |""".stripMargin)
+  mapping
+}

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/project/build.properties
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.1

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/project/plugins.sbt
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.github.jxnu-liguobin" % "graphql-codegen-sbt-plugin" % "2.4.1-SNAPSHOT")

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/src/main/resources/log4j2.xml
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/src/main/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%d{ISO8601}] [%-5p] [%t#%T] %c#%L - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="io.github" level="info" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/src/main/resources/schema.graphqls
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/src/main/resources/schema.graphqls
@@ -1,0 +1,44 @@
+schema {
+    query: Query
+}
+
+type Query {
+    hero(episode: Episode) : Character
+    human(id : String) : Human
+    humans: [Human]
+    droid(id: ID!) : Droid
+}
+enum Episode {
+    NEWHOPE
+    EMPIRE
+    JEDI
+}
+
+interface Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]!
+    secretBackstory : String @deprecated(reason : "We have decided that this is not canon")
+}
+
+type Human implements Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]!
+    homePlanet: String
+    secretBackstory : String @deprecated(reason : "We have decided that this is not canon")
+    email: Email!
+}
+
+type Droid implements Character {
+    id: ID!
+    name: String!
+    friends: [Character]
+    appearsIn: [Episode]!
+    primaryFunction: String
+    secretBackstory : String @deprecated(reason : "We have decided that this is not canon")
+}
+
+scalar Email

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/src/main/scala/io/github/dreamylost/Jackson.scala
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/src/main/scala/io/github/dreamylost/Jackson.scala
@@ -1,0 +1,18 @@
+package io.github.dreamylost
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include
+import com.fasterxml.jackson.databind.{ DeserializationFeature, ObjectMapper }
+import com.fasterxml.jackson.module.scala.{ DefaultScalaModule, ScalaObjectMapper }
+
+object Jackson {
+
+  lazy val mapper: ObjectMapper with ScalaObjectMapper = {
+    val mapper = new ObjectMapper() with ScalaObjectMapper
+    mapper.setSerializationInclusion(Include.NON_NULL)
+    mapper.setSerializationInclusion(Include.NON_ABSENT)
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    mapper.registerModule(DefaultScalaModule)
+    mapper
+  }
+
+}

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/src/main/scala/io/github/dreamylost/OkHttp.scala
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/src/main/scala/io/github/dreamylost/OkHttp.scala
@@ -1,0 +1,70 @@
+package io.github.dreamylost
+
+import java.io.IOException
+import java.util
+import java.util.concurrent.TimeUnit
+
+import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLRequest
+import okhttp3._
+import org.json.JSONObject
+
+import scala.concurrent.{ ExecutionContext, Future, Promise }
+
+object OkHttp {
+
+  import com.fasterxml.jackson.core.`type`.TypeReference
+
+  var url = "http://localhost:8080/graphql"
+  val defaultCharset = "utf8"
+  val json = MediaType.parse("application/json; charset=utf-8")
+
+  private lazy val defaultTimeout: Long = TimeUnit.MINUTES.toMillis(1)
+  lazy val client: OkHttpClient = buildClient(defaultTimeout, defaultTimeout, defaultTimeout)
+
+  def buildClient(readTimeout: Long, writeTimeout: Long, connectTimeout: Long): OkHttpClient = {
+    new OkHttpClient.Builder()
+      .readTimeout(readTimeout, TimeUnit.MILLISECONDS)
+      .writeTimeout(writeTimeout, TimeUnit.MILLISECONDS)
+      .connectTimeout(connectTimeout, TimeUnit.MILLISECONDS)
+      .protocols(util.Arrays.asList(Protocol.HTTP_1_1, Protocol.HTTP_2))
+      .build()
+  }
+
+  /**
+   *
+   * @param request
+   * @param valueType must get from invoker, ClassTag is invalid
+   * @param ec
+   * @tparam T
+   * @return
+   */
+  def executeRequest[T](request: GraphQLRequest, valueType: TypeReference[T])(implicit ec: ExecutionContext): Future[T] = {
+    val rb = new Request.Builder().url(url).addHeader("Accept", "application/json; charset=utf-8").
+      post(RequestBody.create(request.toHttpJsonBody, json))
+    val promise = Promise[T]
+
+    OkHttp.client.newCall(rb.build()).enqueue(new Callback {
+
+      override def onFailure(call: Call, e: IOException): Unit = {
+        promise.failure(e)
+      }
+
+      override def onResponse(call: Call, response: Response): Unit = {
+        if (response.isSuccessful) {
+          //          val clazz = implicitly[ClassTag[T]].runtimeClass
+          val bytes = response.body().bytes()
+          val jsonStr = new String(bytes, defaultCharset)
+          val jsonObject = new JSONObject(jsonStr)
+          val res = jsonObject.getJSONObject("data").get(request.getRequest.getOperationName)
+          val result = Jackson.mapper.readValue(res.toString, valueType)
+          promise.success(result.asInstanceOf[T])
+
+        } else {
+          Future.successful()
+        }
+
+      }
+    })
+    promise.future
+  }
+}

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/src/main/scala/io/github/dreamylost/scalar/EmailScalar.java
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/src/main/scala/io/github/dreamylost/scalar/EmailScalar.java
@@ -1,0 +1,70 @@
+package io.github.dreamylost.scalar;
+
+import graphql.language.StringValue;
+import graphql.schema.*;
+
+import java.util.regex.Pattern;
+
+/**
+ * graphql scalar type
+ * <p>
+ * use in graphql schema like : scalar Email
+ *
+ * @author 梦境迷离
+ * @time 2020年04月03日
+ */
+public class EmailScalar {
+
+    public static final GraphQLScalarType Email = new GraphQLScalarType("Email", "A custom scalar that handles emails", new Coercing() {
+        @Override
+        public Object serialize(Object dataFetcherResult) {
+            return serializeEmail(dataFetcherResult);
+        }
+
+        @Override
+        public Object parseValue(Object input) {
+            return parseEmailFromVariable(input);
+        }
+
+        @Override
+        public Object parseLiteral(Object input) {
+            return parseEmailFromAstLiteral(input);
+        }
+    });
+
+
+    private static boolean looksLikeAnEmailAddress(String possibleEmailValue) {
+        return Pattern.matches("^[A-Za-z0-9\\u4e00-\\u9fa5]+@[a-zA-Z0-9_-]+(\\.[a-zA-Z0-9_-]+)+$", possibleEmailValue);
+    }
+
+    private static Object serializeEmail(Object dataFetcherResult) {
+        String possibleEmailValue = String.valueOf(dataFetcherResult);
+        if (looksLikeAnEmailAddress(possibleEmailValue)) {
+            return possibleEmailValue;
+        } else {
+            throw new CoercingSerializeException("Unable to serialize " + possibleEmailValue + " as an email address");
+        }
+    }
+
+    private static Object parseEmailFromVariable(Object input) {
+        if (input instanceof String) {
+            String possibleEmailValue = input.toString();
+            if (looksLikeAnEmailAddress(possibleEmailValue)) {
+                return possibleEmailValue;
+            }
+        }
+        throw new CoercingParseValueException("Unable to parse variable value " + input + " as an email address");
+    }
+
+    private static Object parseEmailFromAstLiteral(Object input) {
+        if (input instanceof StringValue) {
+            String possibleEmailValue = ((StringValue) input).getValue();
+            if (looksLikeAnEmailAddress(possibleEmailValue)) {
+                return possibleEmailValue;
+            }
+        }
+        throw new CoercingParseLiteralException(
+                "Value is not any email address : '" + input + "'"
+        );
+    }
+}

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/src/main/scala/io/github/dreamylost/service/QueryResolverImpl.scala
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/src/main/scala/io/github/dreamylost/service/QueryResolverImpl.scala
@@ -1,0 +1,71 @@
+package io.github.dreamylost.service
+
+import java.util
+
+import com.fasterxml.jackson.core.`type`.TypeReference
+import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLRequest
+import io.github.dreamylost.api.QueryResolver
+import io.github.dreamylost.OkHttp
+import io.github.dreamylost.model._
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/**
+ * a scala client example
+ *
+ * @author liguobin@growingio.com
+ * @version 1.0,2020/7/20
+ */
+class QueryResolverImpl extends QueryResolver {
+
+  @throws[Exception]
+  def hero(episode: EpisodeDO): CharacterDO = {
+    val heroQueryRequest = new HeroQueryRequest
+    heroQueryRequest.setEpisode(episode)
+    //must use typename, and add jackson annotation to support, since v2.4
+    val characterResponseProjection = new CharacterResponseProjection().id().name().typename()
+      .friends(new CharacterResponseProjection().id().name().typename()).appearsIn()
+    val graphQLRequest = new GraphQLRequest(heroQueryRequest, characterResponseProjection)
+    val retFuture = OkHttp.executeRequest(graphQLRequest, new TypeReference[CharacterDO] {})
+    val ret = Await.result(retFuture, Duration.Inf)
+    ret
+  }
+
+  @throws[Exception]
+  def human(id: String): HumanDO = {
+    val humanQueryRequest = new HumanQueryRequest
+    humanQueryRequest.setId(id)
+    //must use typename, and add jackson annotation to support, since v2.4
+    val humanResponseProjection = new HumanResponseProjection().id().name().typename()
+    val graphQLRequest = new GraphQLRequest(humanQueryRequest, humanResponseProjection)
+    val retFuture = OkHttp.executeRequest(graphQLRequest, new TypeReference[HumanDO] {})
+    val ret = Await.result(retFuture, Duration.Inf)
+    ret
+  }
+
+  @throws[Exception]
+  def humans: util.List[HumanDO] = {
+    import scala.collection.JavaConverters._
+    val humanQueryRequest = new HumansQueryRequest
+    //must use typename, and add jackson annotation to support, since v2.4
+    val humanResponseProjection = new HumanResponseProjection().id().name().typename()
+    val graphQLRequest = new GraphQLRequest(humanQueryRequest, humanResponseProjection)
+    val retFuture = OkHttp.executeRequest(graphQLRequest, new TypeReference[List[HumanDO]] {})
+    val ret = Await.result(retFuture, Duration.Inf)
+    ret.asJava
+  }
+
+  @throws[Exception]
+  def droid(id: String): DroidDO = {
+    val productByIdQueryRequest = new DroidQueryRequest
+    productByIdQueryRequest.setId(id)
+    //must use typename, and add jackson annotation to support, since v2.4
+    val droidResponseProjection = new DroidResponseProjection().id().name().typename()
+    val graphQLRequest = new GraphQLRequest(productByIdQueryRequest, droidResponseProjection)
+    val retFuture = OkHttp.executeRequest(graphQLRequest, new TypeReference[DroidDO] {})
+    val ret = Await.result(retFuture, Duration.Inf)
+    ret
+  }
+}

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/src/main/scala/io/github/dreamylost/service/QueryResolverImplMain.scala
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/src/main/scala/io/github/dreamylost/service/QueryResolverImplMain.scala
@@ -1,0 +1,34 @@
+package io.github.dreamylost.service
+
+import io.github.dreamylost.model.EpisodeDO
+
+import scala.collection.JavaConverters._
+
+/**
+ *
+ * @author liguobin@growingio.com
+ * @version 1.0,2020/7/21
+ */
+object QueryResolverImplMain extends App {
+
+  val droidResolver = new QueryResolverImpl
+
+  // need typename on Projection
+  println("=======get droid id 2001=========")
+  val d = droidResolver.droid("2001")
+  println(d)
+
+  println("=======get humans all=======")
+  val hums = droidResolver.humans
+  for (h <- hums.asScala) {
+    println(h)
+  }
+
+  println("=======get human id 1002=======")
+  val hum = droidResolver.human("1002")
+  println(hum)
+
+  println("=======get hero Episode.EMPIRE=======")
+  val character = droidResolver.hero(EpisodeDO.EMPIRE)
+  println(character)
+}

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/test
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/example-client/test
@@ -1,0 +1,6 @@
+# check if the file gets created
+> graphqlCodegen
+> graphqlSchemaValidate src/main/resources/schema.graphqls
+> graphqlCodegenValidate
+> compile
+$ exists target/scala-2.12/src_managed_graphql/io/github/dreamylost/model/CharacterDO.java

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/simple/build.sbt
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/simple/build.sbt
@@ -1,0 +1,12 @@
+name := "simple"
+
+lazy val root = (project in file("."))
+  .settings(
+    version := "0.1",
+    scalaVersion := "2.13.2",
+    apiPackageName := Some("io.github.kobylynskyi.graphql.test.api"),
+    modelPackageName := Some("io.github.kobylynskyi.graphql.test.model"),
+    apiAsyncReturnType := "scala.concurrent.Future", // if Async class is not at current source, need import dependency
+    generateAsyncApi := true
+    //use full class name is good
+  ).enablePlugins(GraphQLCodegenPlugin).settings(GraphQLCodegenPluginDependencies)

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/simple/project/build.properties
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/simple/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.1

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/simple/project/plugins.sbt
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/simple/project/plugins.sbt
@@ -1,0 +1,5 @@
+sys.props.get("plugin.version").orElse(Some("2.4.1-SNAPSHOT")) match {
+  case Some(x) => addSbtPlugin("io.github.jxnu-liguobin" % "graphql-codegen-sbt-plugin" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/simple/src/main/resources/schema.graphql
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/simple/src/main/resources/schema.graphql
@@ -1,0 +1,37 @@
+#
+# Schemas must have at least a query root type
+#
+schema {
+    query: Query
+}
+
+# This is the type that will be the root of our query, and the
+# entry point into our schema.
+type Query {
+    getPosts: [Post]
+
+    getUser(
+        id : ID!
+    ): User
+
+    getPost(
+        id: ID!
+    ): Post
+}
+
+type Post {
+    id: ID!
+    title: String!
+    # Content if provided by author
+    content: String
+    # The URL if this is external content
+    url: String
+    author: User
+}
+
+type User {
+    id: ID!
+    username: String!
+    email: String!
+    posts: [Post]
+}

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/simple/src/main/scala/io/github/kobylynskyi/graphql/test/api/impl/GetUserQueryResolverImpl.scala
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/simple/src/main/scala/io/github/kobylynskyi/graphql/test/api/impl/GetUserQueryResolverImpl.scala
@@ -1,0 +1,19 @@
+package io.github.kobylynskyi.graphql.test.api.impl
+
+import io.github.kobylynskyi.graphql.test.api.GetUserQueryResolver
+import io.github.kobylynskyi.graphql.test.model.User
+
+import scala.concurrent.Future
+
+/**
+ * example, use a async api
+ *
+ * @author 梦境迷离 dreamylost
+ * @since 2020-07-19
+ * @version v1.0
+ */
+class GetUserQueryResolverImpl extends GetUserQueryResolver {
+  override def getUser(id: _root_.java.lang.String): _root_.scala.concurrent.Future[_root_.io.github.kobylynskyi.graphql.test.model.User] = {
+    Future.successful(User.builder().setId("id").setEmail("email@126.com").setUsername("user name").build())
+  }
+}

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/simple/test
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/sbt-test/graphql-codegen-sbt-plugin/simple/test
@@ -1,0 +1,6 @@
+# check if the file gets created
+> graphqlCodegen
+> graphqlSchemaValidate src/main/resources/schema.graphql
+> graphqlCodegenValidate
+> compile
+$ exists target/scala-2.13/src_managed_graphql/io/github/kobylynskyi/graphql/test/model/User.java

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/src/test/scala/test/Test.scala
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/src/test/scala/test/Test.scala
@@ -1,0 +1,14 @@
+package test
+
+/**
+ *
+ * @author liguobin@growingio.com
+ * @version 1.0,2020/7/15
+ */
+object Test {
+
+  import io.github.dreamylost.graphql.codegen.GraphQLCodegenPlugin
+
+  val s = GraphQLCodegenPlugin
+
+}

--- a/plugins/sbt/graphql-java-codegen-sbt-plugin/version.sbt
+++ b/plugins/sbt/graphql-java-codegen-sbt-plugin/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "2.4.1-SNAPSHOT"


### PR DESCRIPTION
* add sbt plugin

* rm log to file

* update

* update readme

* update readme

* update readme

* update client example

* update client example

* update log

* update client example

* add scalaiform

* add scalaiform and publish

* support schemaFinderConfig and parentInterfacesConfig

* update readme license, convert GraphQLCodegen to Def

* update readme

* Create scala.yml

* update scala ci

* update scala ci

* rm scala ci

* rm scala ci

* use publishLocal

* ci support ivy cache

* ci support ivy cache

* fix support ivy cache

* change example project level

* change example project level

* fix path for ci

* fix workflows

* move generate code to src_managed_graphql

* change generate code location to src_managed_graphql

* add sbt-test for plugin

* fix workflows

* fix workflows

* change generate code location to src_managed_graphql

* add watch resource, refactor plugins

* add developer for publish

* add key apiAsyncReturnType and apiAsyncReturnListType,
refactor code, update sbt-test with two options

* add resolvers

* add resolvers for ci

* add resolvers for ci

* add resolvers for ci

* Remove redundant dependencies

* fix support ivy local

* Update github.yml

* fix support ivy local

* update ci

* fix compile failed when generate code  not found in classpath. test in the standard way

* Update github.yml

* 1. update default option code
2. update client example
3. update version to 2.3.0

* update version to 2.3.0

* Merge branch 'master' of github.com:jxnu-liguobin/graphql-java-codegen

* pre release  2.4.0

* next dev 2.4.1-SNAPSHOT
fix example support with v2.4.0 add typename