### PR TITLE
Update migration guide for SBT plugin (#290)

### DIFF
--- a/docs/migration-to-3.0.0.md
+++ b/docs/migration-to-3.0.0.md
@@ -42,6 +42,17 @@ apiReturnListType=reactor.core.publisher.Flux
 // NEW APPROACH
 ```
 
+#### SBT
+```sbt
+// OLD APPROACH
+generateAsyncApis := true
+apiAsyncReturnType := "scala.concurrent.Future"
+// OLD APPROACH
+
+// NEW APPROACH
+apiReturnType := Some("scala.concurrent.Future")
+// NEW APPROACH
+```
 
 ### 3. Update plugin configuration for `customAnnotationsMapping` and `directiveAnnotationsMapping`
 If you have used `customAnnotationsMapping` or `directiveAnnotationsMapping` config options, then it should be updated by providing an array of annotations in the following format:
@@ -103,6 +114,40 @@ directiveAnnotationsMapping = [
 // NEW APPROACH
 ```
 
+#### SBT
+```sbt
+// OLD APPROACH
+customAnnotationsMapping := {
+  val mapping = new util.HashMap[String, String]
+  //must add this annotation
+  //property is __typename and you must use with __typename while invoke, like new CharacterResponseProjection().id().name().typename()
+  //and in @JsonSubTypes.Type, name is __typename's value
+  mapping.put("Character",
+    s"""@com.fasterxml.jackson.annotation.JsonTypeInfo(use=com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME, include=com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,property = "__typename")${System.lineSeparator()}@com.fasterxml.jackson.annotation.JsonSubTypes(value = {
+      |        @com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = HumanDO.class, name = "Human"),
+      |        @com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = DroidDO.class, name = "Droid")})
+      |""".stripMargin)
+  mapping
+}
+// OLD APPROACH
+
+// NEW APPROACH
+customAnnotationsMapping := {
+  val mapping = new util.HashMap[String, util.List[String]]
+  val annotations = new util.ArrayList[String]()
+  annotations.add("@com.fasterxml.jackson.annotation.JsonTypeInfo(use=com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME, include=com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,property = \"__typename\")")
+  annotations.add("""@com.fasterxml.jackson.annotation.JsonSubTypes(value = {
+                    |        @com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = HumanDO.class, name = "Human"),
+                    |        @com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = DroidDO.class, name = "Droid")})""".stripMargin)
+  //must add this annotation
+  //property is __typename and you must use with __typename while invoke, like new CharacterResponseProjection().id().name().typename()
+  //and in @JsonSubTypes.Type, name is __typename's value
+  mapping.put("Character", annotations)
+  mapping
+}
+// NEW APPROACH
+```
+`directiveAnnotationsMapping`, In the same way.
 
 
 ### 4. Regenerate the code

--- a/plugins/sbt/README.md
+++ b/plugins/sbt/README.md
@@ -84,7 +84,8 @@ SBT task
 
 Please refer to [Codegen Options](../../docs/codegen-options.md)
 
-> in sbt plugin option `packageName` was rename to `generatePackageName`
-> in sbt plugin option `generateCodegenTargetPath` can be used for setting codegen path where code have be created by task `graphqlCodegen`
+> in sbt plugin option 
+- `packageName` was rename to `generatePackageName`
+- `generateCodegenTargetPath` can be used for setting codegen path where code have bean created by task `graphqlCodegen`, since 3.0.0 .
 
 


### PR DESCRIPTION
* add sbt plugin

* rm log to file

* update

* update readme

* update readme

* update readme

* update client example

* update client example

* update log

* update client example

* add scalaiform

* add scalaiform and publish

* support schemaFinderConfig and parentInterfacesConfig

* update readme license, convert GraphQLCodegen to Def

* update readme

* Create scala.yml

* update scala ci

* update scala ci

* rm scala ci

* rm scala ci

* use publishLocal

* ci support ivy cache

* ci support ivy cache

* fix support ivy cache

* change example project level

* change example project level

* fix path for ci

* fix workflows

* move generate code to src_managed_graphql

* change generate code location to src_managed_graphql

* add sbt-test for plugin

* fix workflows

* fix workflows

* change generate code location to src_managed_graphql

* add watch resource, refactor plugins

* add developer for publish

* add key apiAsyncReturnType and apiAsyncReturnListType,
refactor code, update sbt-test with two options

* add resolvers

* add resolvers for ci

* add resolvers for ci

* add resolvers for ci

* Remove redundant dependencies

* fix support ivy local

* Update github.yml

* fix support ivy local

* update ci

* fix compile failed when generate code  not found in classpath. test in the standard way

* Update github.yml

* 1. update default option code
2. update client example
3. update version to 2.3.0

* update version to 2.3.0

* Merge branch 'master' of github.com:jxnu-liguobin/graphql-java-codegen

* pre release  2.4.0

* next dev 2.4.1-SNAPSHOT
fix example support with v2.4.0 add typename

* add use case with proxy

* add comment

* add Support code

* update README

* add scope on conf key

* add release plugin

* add release plugin

* Setting version to 2.4.2

* Setting version to 2.4.3-SNAPSHOT

* add release plugin (not release)

* upgrade sbt version, update example Deprecated api

* refactor sbt plugin

* refactor sbt plugin

* :recycle: Changes for upcoming release 3.0.0 (#276)

* Setting version to 3.0.0

* fix conflict， release3.0.0

* append migration

* append migration